### PR TITLE
Add GitHub Link to Navigation Bar

### DIFF
--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -1,12 +1,21 @@
 import React from "react";
 import "../styles/NavBar.css";
-import { FaReact } from "react-icons/fa";
+import { FaReact, FaGithub } from "react-icons/fa";
 
 function NavBar() {
   return (
     <nav className="navbar">
       <div className="navbar-logo">
-        <FaReact className="logo-icon" /> SA ID Generator
+        <FaReact className="logo-icon" /> SA ID Generatorss
+      </div>
+      <div className="navbar-github">
+        <a
+          href="https://github.com/MandlaHlaoli/sa-id-number-generator"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <FaGithub className="github-icon" /> GitHub Repo
+        </a>
       </div>
     </nav>
   );

--- a/src/styles/NavBar.css
+++ b/src/styles/NavBar.css
@@ -3,7 +3,6 @@
     top: 0;
     width: 100%;
     background-color: #2c3e50;
-    /* Dark background */
     color: #ecf0f1;
     padding: 10px 20px;
     display: flex;
@@ -18,33 +17,31 @@
     font-weight: bold;
 }
 
-.navbar-links {
-    list-style: none;
-    margin: 0;
-    padding: 0;
+.navbar-github {
     display: flex;
-    gap: 15px;
+    align-items: center;
 }
 
-.navbar-links li {
-    display: inline;
-}
-
-.navbar-links a {
+.navbar-github a {
     color: #ecf0f1;
     text-decoration: none;
     font-size: 1em;
+    display: flex;
+    align-items: center;
     padding: 5px 10px;
     border-radius: 4px;
 }
 
-.navbar-links a:hover {
+.navbar-github a:hover {
     background-color: #3498db;
-    /* Hover background color */
     color: #fff;
+}
+
+.github-icon {
+    margin-right: 8px;
+    font-size: 1.5em;
 }
 
 body {
     margin-top: 70px;
-   
 }


### PR DESCRIPTION
This PR adds a GitHub link to the navigation bar, allowing users to easily access the repository for the SA ID Generator app.

1. _Added:_ FaGithub icon from `react-icons/fa` to display the GitHub logo in the navigation bar.
2. _Updated:_ Navigation bar to include a new link that opens the repository in a new tab.

**Modified CSS:**
1. `Styled` .navbar-github for proper alignment of the GitHub icon and text.
2. Ensured the link styling is consistent with the rest of the navigation links.
3. Added hover effects and spacing to improve user experience.
4. This change enhances visibility for developers who may want to contribute to the project directly from the app interface.